### PR TITLE
remove unused package

### DIFF
--- a/Julia Files/SymplecticBA.jl
+++ b/Julia Files/SymplecticBA.jl
@@ -21,7 +21,6 @@ import Pkg; Pkg.activate(@__DIR__); Pkg.instantiate()
 
 using BSeries
 using RootedTrees
-using Latexify
 
 # ## The Interesting Part
 # Now I can start to define the functions needed for checking the symplecticity of a method.


### PR DESCRIPTION
Latexify.jl is not used for the symplectic examples. Since it's also not contained in the Project.toml, I removed it